### PR TITLE
Makes OscClient socket and writer protected

### DIFF
--- a/Runtime/Scripts/OscClient.cs
+++ b/Runtime/Scripts/OscClient.cs
@@ -7,8 +7,8 @@ namespace OscCore
 {
     public class OscClient
     {
-        readonly Socket m_Socket;
-        readonly OscWriter m_Writer;
+        protected readonly Socket m_Socket;
+        protected readonly OscWriter m_Writer;
 
         /// <summary>Serializes outgoing messages</summary>
         public OscWriter Writer => m_Writer;


### PR DESCRIPTION
This enables easy extensions of the OscClient class which can add their own typed sending methods