### PR TITLE
Avatars failed to load when using special characters in Expression Parameters

### DIFF
--- a/Runtime/Scripts/OscAddressSpace.cs
+++ b/Runtime/Scripts/OscAddressSpace.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -12,7 +11,7 @@ namespace OscCore
         const int k_DefaultCapacity = 16;
 
         StringBuilder escapedStringBuilder = new StringBuilder();
-        char[] specialRegexCharacters = new char[] { '.', '^', '$', '*', '+', '?', '{', '}', '[', ']', '\\', '|', '(', ')' };
+        HashSet<char> specialRegexCharactersSet = new HashSet<char>(new char[] { '.', '^', '$', '*', '+', '?', '{', '}', '[', ']', '\\', '|', '(', ')' });
 
         internal readonly OscAddressMethods AddressToMethod;
         

--- a/Runtime/Scripts/OscAddressSpace.cs
+++ b/Runtime/Scripts/OscAddressSpace.cs
@@ -11,7 +11,7 @@ namespace OscCore
         const int k_DefaultCapacity = 16;
 
         StringBuilder escapedStringBuilder = new StringBuilder();
-        HashSet<char> specialRegexCharactersSet = new HashSet<char>(new char[] { '.', '^', '$', '*', '+', '?', '{', '}', '[', ']', '\\', '|', '(', ')' });
+        HashSet<char> specialRegexCharacters = new HashSet<char>(new char[] { '.', '^', '$', '*', '+', '?', '{', '}', '[', ']', '\\', '|', '(', ')' });
 
         internal readonly OscAddressMethods AddressToMethod;
         


### PR DESCRIPTION
https://linear.app/vrchat/issue/REL-928/expression-parameter-called-[add-on]-internally-crashes-osccore-and

This solution tries to handle the address as is, and if it fails to make the RegEx, it attempts to escape any RegEx-specific characters and it tries again.