### PR TITLE
REL-4001 Fix incorrect offset in `IsBundleTagAtIndex`

### DIFF
--- a/Runtime/Scripts/OscParser.cs
+++ b/Runtime/Scripts/OscParser.cs
@@ -274,7 +274,16 @@ namespace OscCore
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsBundleTagAtIndex(int index)
         {
-            return *(long*)(BufferPtr + index) == Constant.BundlePrefixLong;
+            //return *((long*)BufferPtr + index) == Constant.BundlePrefixLong;
+
+            // VRChat, safety: to prevent issues with unaligned reads or incorrect pointer arithmetic (can you spot the bug above?),
+            // we just do this the safe way in managed land.
+            for (int i = 0; i < 8; i++)
+            {
+                if (Buffer[index + i] != Constant.BundlePrefixBytes[i])
+                    return false;
+            }
+            return true;
         }
         
         public static int FindArrayLength(byte[] bytes, int offset = 0)

--- a/Runtime/Scripts/OscParser.cs
+++ b/Runtime/Scripts/OscParser.cs
@@ -25,7 +25,7 @@ namespace OscCore
         public OscParser(byte[] fixedBuffer)
         {
             Buffer = fixedBuffer;
-            fixed (byte* ptr = fixedBuffer)
+            fixed (byte* ptr = fixedBuffer) // safety: pinned by caller via GCHandle, see OscServer.cs
             {
                 BufferPtr = ptr;
                 BufferLongPtr = (long*) ptr;
@@ -274,7 +274,7 @@ namespace OscCore
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsBundleTagAtIndex(int index)
         {
-            return *((long*) BufferPtr + index) == Constant.BundlePrefixLong;
+            return *(long*)(BufferPtr + index) == Constant.BundlePrefixLong;
         }
         
         public static int FindArrayLength(byte[] bytes, int offset = 0)


### PR DESCRIPTION
The cast order meant that `index` was offsetting by `sizeof(long)`, but the caller wanted it to be a byte offset. We don't use nested bundles anywhere, so this broken functionality never materialized, but if `index` was large enough it would dereference the pointer way beyond the buffer and potentially into unmapped memory land.

Co-Developed-By: Claude Opus 4.8